### PR TITLE
Only split the first = when overriding extra_args

### DIFF
--- a/ailib/__init__.py
+++ b/ailib/__init__.py
@@ -649,7 +649,7 @@ class AssistedClient(object):
                         self.client.v2_update_host_ignition(infra_env_id, host_id, host_ignition_params)
                 if 'extra_args' in overrides:
                     extra_args = overrides['extra_args']
-                    extra_args = sum([entry.split('=') for entry in extra_args.split(" ")], [])
+                    extra_args = sum([entry.split('=',1) for entry in extra_args.split(" ")], [])
                     installer_args_params = models.InstallerArgsParams(args=extra_args)
                     self.client.v2_update_host_installer_args(infra_env_id, host_id, installer_args_params)
                     extra_args_updated = True


### PR DESCRIPTION
If split every "=" then the kargs can not be configured correctly with the following errors:
$ aicli info host master-2 | grep karg
installer_args: ["--append-karg","iommu","pt"]
status_info: Failed - failed after 3 attempts, last error: failed executing nsenter [--target 1 --cgroup --mount --ipc --pid -- coreos-installer install --insecure -i /opt/install-dir/master-ae885ef6-4f54-4701-a32b-e369dd24287f.ign --append-karg iommu pt --append-karg ip=enp1s0:dhcp /dev/vda], Error exit status 1, LastOutput "... '/dev/vda' which wasn't expected, or isn't valid in this context
    coreos-installer install <device> --append-karg <arg>... --ignition-file <path> --insecure