### PR TITLE
quoting all mac addresses in samples to show best practice

### DIFF
--- a/samples/billi.yml
+++ b/samples/billi.yml
@@ -20,7 +20,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:21
+      mac-address: 'de:ad:bb:ef:00:21'
   dns-resolver:
     config:
       server:
@@ -48,7 +48,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:22
+      mac-address: 'de:ad:bb:ef:00:22'
   dns-resolver:
     config:
       server:
@@ -76,7 +76,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:23
+      mac-address: 'de:ad:bb:ef:00:23'
   dns-resolver:
     config:
       server:
@@ -104,7 +104,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:24
+      mac-address: 'de:ad:bb:ef:00:24'
   dns-resolver:
     config:
       server:

--- a/samples/billi_disconnected.yml
+++ b/samples/billi_disconnected.yml
@@ -20,7 +20,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:21
+      mac-address: 'de:ad:bb:ef:00:21'
   dns-resolver:
     config:
       server:
@@ -48,7 +48,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:22
+      mac-address: 'de:ad:bb:ef:00:22'
   dns-resolver:
     config:
       server:
@@ -76,7 +76,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:23
+      mac-address: 'de:ad:bb:ef:00:23'
   dns-resolver:
     config:
       server:
@@ -104,7 +104,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:24
+      mac-address: 'de:ad:bb:ef:00:24'
   dns-resolver:
     config:
       server:

--- a/samples/billi_disconnected_dual.yml
+++ b/samples/billi_disconnected_dual.yml
@@ -33,7 +33,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:21
+      mac-address: 'de:ad:bb:ef:00:21'
   dns-resolver:
     config:
       server:
@@ -69,7 +69,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:22
+      mac-address: 'de:ad:bb:ef:00:22'
   dns-resolver:
     config:
       server:
@@ -105,7 +105,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:23
+      mac-address: 'de:ad:bb:ef:00:23'
   dns-resolver:
     config:
       server:

--- a/samples/billi_disconnected_ipv6.yml
+++ b/samples/billi_disconnected_ipv6.yml
@@ -24,7 +24,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:21
+      mac-address: 'de:ad:bb:ef:00:21'
   dns-resolver:
     config:
       server:
@@ -48,7 +48,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:22
+      mac-address: 'de:ad:bb:ef:00:22'
   dns-resolver:
     config:
       server:
@@ -72,7 +72,7 @@ static_network_config:
           prefix-length: 64
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:23
+      mac-address: 'de:ad:bb:ef:00:23'
   dns-resolver:
     config:
       server:

--- a/samples/bonding.yml
+++ b/samples/bonding.yml
@@ -29,9 +29,9 @@ static_network_config:
       server:
         - 192.168.123.1
   mac_interface_map:
-  - mac_address: aa:aa:aa:aa:cc:01
+  - mac_address: 'aa:aa:aa:aa:cc:01'
     logical_nic_name: ens3
-  - mac_address: aa:aa:aa:aa:cc:02
+  - mac_address: 'aa:aa:aa:aa:cc:02'
     logical_nic_name: ens4
 - interfaces:
   - name: bond0
@@ -60,9 +60,9 @@ static_network_config:
       server:
         - 192.168.123.1
   mac_interface_map:
-  - mac_address: aa:aa:aa:aa:cc:03
+  - mac_address: 'aa:aa:aa:aa:cc:03'
     logical_nic_name: ens3
-  - mac_address: aa:aa:aa:aa:cc:04
+  - mac_address: 'aa:aa:aa:aa:cc:04'
     logical_nic_name: ens4
 - interfaces:
   - name: bond0
@@ -91,7 +91,7 @@ static_network_config:
       server:
         - 192.168.123.1
   mac_interface_map:
-   - mac_address: aa:aa:aa:aa:cc:05
+   - mac_address: 'aa:aa:aa:aa:cc:05'
      logical_nic_name: ens3
-   - mac_address: aa:aa:aa:aa:cc:06
+   - mac_address: 'aa:aa:aa:aa:cc:06'
      logical_nic_name: ens4

--- a/samples/static_network_config.yml
+++ b/samples/static_network_config.yml
@@ -16,7 +16,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:21
+      mac-address: 'de:ad:bb:ef:00:21'
   dns-resolver:
     config:
       server:
@@ -44,7 +44,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:22
+      mac-address: 'de:ad:bb:ef:00:22'
   dns-resolver:
     config:
       server:
@@ -72,7 +72,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:23
+      mac-address: 'de:ad:bb:ef:00:23'
   dns-resolver:
     config:
       server:
@@ -100,7 +100,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:24
+      mac-address: 'de:ad:bb:ef:00:24'
   dns-resolver:
     config:
       server:
@@ -128,7 +128,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:25
+      mac-address: 'de:ad:bb:ef:00:25'
   dns-resolver:
     config:
       server:

--- a/samples/static_network_config_sno.yml
+++ b/samples/static_network_config_sno.yml
@@ -13,7 +13,7 @@ static_network_config:
           prefix-length: 24
         enabled: true
       mtu: 1500
-      mac-address: de:ad:bb:ef:00:25
+      mac-address: 'de:ad:bb:ef:00:25'
   dns-resolver:
     config:
       server:


### PR DESCRIPTION
Great job on this tool! I was using the tool the other day and found when working from the samples that there are certain MAC addresses that get recognized as "numeric" instead of a string. (I found that if the MAC address has '00:0N' (where N is a number) as part of the mac address, for example "52:54:00:06:56:24" it is identified by the Go parser as a numeric.)

This results in an error:

```
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Fri, 02 Sep 2022 12:27:53 GMT', 'Content-Length': '224'})
HTTP response body: {"code":400,"message":"parsing infraenvCreateParams body from \"\" failed, because json: cannot unmarshal number into Go struct field MacInterfaceMapItems0.static_network_config.mac_interface_map.mac_address of type string"}
```

This can be fixed by putting the mac address in single quotes. It is an edge case (and may even be a Go bug), but I figured updating the sample files with the MAC addresses quoted, might help others down the road avoid this edge case.