### PR TITLE
raise exception instead of only printing when failed to boot host

### DIFF
--- a/ailib/__init__.py
+++ b/ailib/__init__.py
@@ -63,6 +63,7 @@ def boot_hosts(overrides, hostnames=[], debug=False):
                 red.set_iso(iso_url)
             except Exception as e:
                 warning(f"Hit {e} when plugging iso to host {msg}")
+                raise e
 
 
 class AssistedClient(object):


### PR DESCRIPTION
If ailib is used as a library, it's not straightforward to detect when the boot_hosts function fails. Instead of swalling the excpetion and just printing an error, raise it again so that it can be caught and handled gracefully from the caller.