### PR TITLE
Use the full url to determine base url

### DIFF
--- a/ailib/kfish/__init__.py
+++ b/ailib/kfish/__init__.py
@@ -54,7 +54,7 @@ class Redfish(object):
         self.model, self.url, self.user, self.password = get_info(url, user, password)
         if self.debug:
             print(f"Using base url {self.url}")
-        p = urlparse(url)
+        p = urlparse(self.url)
         self.baseurl = f"{p.scheme}://{p.netloc}"
         credentials = base64.b64encode(bytes(f'{self.user}:{self.password}', 'ascii')).decode('utf-8')
         self.headers["Authorization"] = f"Basic {credentials}"


### PR DESCRIPTION
As a result of f9f6a05890b9f28b9c0bc3152764211b09729131, we are no longer using the full url
(https://{url}/redfish/v1/Systems/System.Embedded.1) to derive the base url, which causes self.baseurl to be set incorrectly to "://".

Use the updated self.url rather that url.