### PR TITLE
recognize different ISO URL format

### DIFF
--- a/ailib/__init__.py
+++ b/ailib/__init__.py
@@ -639,6 +639,8 @@ class AssistedClient(object):
 
     def _expired_iso(self, iso_url):
         search = re.search(r".*&image_token=(.*)&type=.*", iso_url)
+        if search is None:
+            search = re.search(r".*/bytoken/(.*?)/.*", iso_url)
         if search is not None:
             encoded_token = search.group(1)
             token = str(base64.urlsafe_b64decode(encoded_token + '==='))


### PR DESCRIPTION
In the infraenv, I'm starting to get ISO download URLs of the form:

```
download_url: https://api.openshift.com/api/assisted-images/bytoken/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2OTg5NTYzOTgsInN1YiI6ImZjZDUzY2I1LTJiNGItNGE1OC05YTQ1LTY2NWVkY2FiMTQ3OCJ9.6SXYbjnJ8PLJBDSipzIh4ZIha1Jfrmi1N0nCnkWOkH8/4.13/x86_64/full.iso
```

I have no idea whether this is a permanent change or it only happens under certain circumstances; for me, it just changed all of a sudden. In any case, this PR adds support for those URLs in `_expired_iso`.