### PR TITLE
Added Lenovo support

### DIFF
--- a/ailib/kfish/__init__.py
+++ b/ailib/kfish/__init__.py
@@ -36,10 +36,22 @@ def get_info(url, user, password):
     except Exception as e:
         print(f"Error: tried accessing URL {request_url}")
         raise e
-    oem = v1data['Oem']
-    model = "dell" if 'Dell' in oem else "hp" if 'Hpe' in oem else 'supermicro' if 'Supermicro' in oem else 'N/A'
+    if 'Oem' in v1data:
+        oem = v1data['Oem']
+        if 'Dell' in oem:
+            model = 'dell'
+        elif 'Hpe' in oem or 'Hp' in oem:
+            model = 'hp'
+        elif 'Supermicro' in oem:
+            model = 'supermicro'
+        else:
+            model = 'N/A'
+    elif 'Vendor' in v1data:
+        vendor = v1data['Vendor']
+        if vendor == 'Lenovo':
+            model = 'lenovo'
     if '://' not in url:
-        if model in ['hp', 'supermicro']:
+        if model in ['hp', 'supermicro', 'lenovo']:
             url = f"https://{url}/redfish/v1/Systems/1"
         elif model == 'dell':
             url = f"https://{url}/redfish/v1/Systems/System.Embedded.1"
@@ -118,10 +130,13 @@ class Redfish(object):
     def get_iso_eject_url(self):
         iso_url = self.get_iso_url()
         request = Request(iso_url, headers=self.headers)
-        actions = json.loads(urlopen(request).read())['Actions']
-        target = '#IsoConfig.UnMount' if self.model == 'supermicro' and self.legacy else '#VirtualMedia.EjectMedia'
-        t = actions[target]['target']
-        ret_data = f"{self.baseurl}{t}"
+        if self.model == 'lenovo':
+            ret_data = f"{iso_url}"
+        else:
+            actions = json.loads(urlopen(request).read())['Actions']
+            target = '#IsoConfig.UnMount' if self.model == 'supermicro' and self.legacy else '#VirtualMedia.EjectMedia'
+            t = actions[target]['target']
+            ret_data = f"{self.baseurl}{t}"
         if self.debug:
             print(f"ISO eject URL is {ret_data}")
         return ret_data
@@ -129,24 +144,34 @@ class Redfish(object):
     def get_iso_insert_url(self):
         iso_url = self.get_iso_url()
         request = Request(iso_url, headers=self.headers)
-        actions = json.loads(urlopen(request).read())['Actions']
-        target = '#IsoConfig.Mount' if self.model == 'supermicro' and self.legacy else '#VirtualMedia.InsertMedia'
-        t = actions[target]['target']
-        ret_data = f"{self.baseurl}{t}"
+        if self.model == 'lenovo':
+            ret_data = f"{iso_url}"
+        else:
+            actions = json.loads(urlopen(request).read())['Actions']
+            target = '#IsoConfig.Mount' if self.model == 'supermicro' and self.legacy else '#VirtualMedia.InsertMedia'
+            t = actions[target]['target']
+            ret_data = f"{self.baseurl}{t}"
         if self.debug:
             print(f"ISO insert URL is {ret_data}")
         return ret_data
 
     def eject_iso(self):
         headers = self.headers.copy()
-        data = json.dumps({}).encode('utf-8')
-        if self.model == 'supermicro' and self.legacy:
-            headers['Content-Length'] = 0
-            # data = {}
         eject_url = self.get_iso_eject_url()
-        if self.debug:
-            print(f"Sending POST to {eject_url} with empty data")
-        request = Request(eject_url, headers=headers, method='POST', data=data)
+        if self.model == 'lenovo':
+            data = {"Inserted": False}
+            data = json.dumps(data).encode('utf-8')
+            request = Request(eject_url, data=data, headers=headers, method='PATCH')
+            if self.debug:
+                print(f"Sending PATCH to {eject_url} with data {data}")
+        else:
+            data = json.dumps({}).encode('utf-8')
+            if self.model == 'supermicro' and self.legacy:
+                headers['Content-Length'] = 0
+                # data = {}
+            request = Request(eject_url, headers=headers, method='POST', data=data)
+            if self.debug:
+                print(f"Sending POST to {eject_url} with empty data")
         return urlopen(request)
 
     def insert_iso(self, iso_url):
@@ -164,10 +189,15 @@ class Redfish(object):
             headers['Content-Length'] = 0
         data = {"Image": iso_url, "Inserted": True}
         insert_url = self.get_iso_insert_url()
-        if self.debug:
-            print(f"Sending POST to {insert_url} with data {data}")
         data = json.dumps(data).encode('utf-8')
-        request = Request(insert_url, data=data, headers=headers)
+        if self.model == 'lenovo':
+            request = Request(insert_url, data=data, headers=headers, method='PATCH')
+            if self.debug:
+                print(f"Sending PATCH to {insert_url} with data {data}")
+        else:
+            request = Request(insert_url, data=data, headers=headers)
+            if self.debug:
+                print(f"Sending POST to {insert_url} with data {data}")
         return urlopen(request)
 
     def set_iso_once(self):


### PR DESCRIPTION
Tested on `ThinkSystem SR650 V2`
Lenovo redfish documentation: https://pubs.lenovo.com/xcc-restapi/insert_eject_virtual_media_patch or same as [PDF](https://pubs.lenovo.com/xcc-restapi/xcc_restapi_book.pdf)

There is a limitation
Lenovo uses 308 redirect as seen in error below and python [added support for it](https://bugs.python.org/issue40321) only in python 3.11

Same 308 redirects seen on `HP 360 Gen8`

IMO this python3.11 prerequisite can be added to documentation and/or to container

```
Error: tried accessing URL https://__MY_LENOVO_SERVER__/redfish/v1
Traceback (most recent call last):
  File "/auto/mtrswgwork/michaelbr/aicli/main/aicli", line 8, in <module>
    sys.exit(cli())
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/cli.py", line 1454, in cli
    args.func(args)
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/cli.py", line 221, in create_deployment
    ai.create_deployment(args.cluster, overrides, force=args.force, debug=args.debugredfish)
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/__init__.py", line 1536, in create_deployment
    boot_result = boot_hosts(boot_overrides, debug=debug)
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/__init__.py", line 61, in boot_hosts
    red = Redfish(bmc_url, bmc_user, bmc_password, debug=debug)
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/kfish/__init__.py", line 74, in __init__
    self.model, self.url, self.user, self.password = get_info(url, user, password)
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/kfish/__init__.py", line 38, in get_info
    raise e
  File "/auto/mtrswgwork/michaelbr/aicli/main/ailib/kfish/__init__.py", line 35, in get_info
    v1data = json.loads(urlopen(request).read())
  File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.10/urllib/request.py", line 525, in open
    response = meth(req, response)
  File "/usr/lib/python3.10/urllib/request.py", line 634, in http_response
    response = self.parent.error(
  File "/usr/lib/python3.10/urllib/request.py", line 563, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.10/urllib/request.py", line 643, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 308: Permanent Redirect

```