### PR TITLE
Added error handling for redfish if virtual media member list is empty

### DIFF
--- a/ailib/kfish/__init__.py
+++ b/ailib/kfish/__init__.py
@@ -104,7 +104,11 @@ class Redfish(object):
         if 'Oem' in results:
             odata = results['Oem']['Supermicro']['VirtualMediaConfig']['@odata.id']
         else:
-            for member in results['Members']:
+            member_list = results['Members']
+            if not member_list:
+                print(f"Error: VirtualMedia Member list in {self.baseurl}{virtual_media_url} is empty")
+                sys.exit(1)
+            for member in member_list:
                 odata = member['@odata.id']
                 if odata.endswith('CD') or odata.endswith('Cd') or odata.endswith('2'):
                     break


### PR DESCRIPTION
It's probably feature/bug of this specific Supermicro server

It returns the following for `https://<IP>/redfish/v1/Managers/1/VirtualMedia`

```
{
  "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
  "@odata.id": "/redfish/v1/Managers/1/VirtualMedia",
  "Name": "Virtual Media Collection",
  "Description": "Collection of Virtual Media for this System",
  "Members": [],
  "Members@odata.count": 0
}
```